### PR TITLE
Hide buffers when using knuckles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /bin/
 /obj/
 /dv
+.idea/
+Directory.Build.targets

--- a/KnuckleCouplers.cs
+++ b/KnuckleCouplers.cs
@@ -4,6 +4,7 @@ using DV.CabControls.Spec;
 using HarmonyLib;
 using System.Collections.Generic;
 using System.Reflection;
+using DV.ThingTypes;
 using UnityEngine;
 
 namespace DvMod.ZCouplers
@@ -20,6 +21,18 @@ namespace DvMod.ZCouplers
             CouplerType couplerType = Main.settings.couplerType.Value;
             hookPrefab = bundle.LoadAsset<GameObject>(couplerType.ToString());
             bundle.Unload(false);
+        }
+
+        public static void RemoveBuffers()
+        {
+            foreach (TrainCarLivery livery in Globals.G.Types.Liveries)
+            {
+                Transform[] children = livery.prefab.GetComponentsInChildren<Transform>();
+                foreach (Transform child in children)
+                    // Search for buffer pads, then buffer stems. Stems aren't named or placed consistently, so we have to generalize.
+                    if (child.name.StartsWith("Buffer_") || child.name.Replace("_", "").ToLowerInvariant().Contains("bufferstem"))
+                        child.gameObject.SetActive(false);
+            }
         }
 
         private static readonly HashSet<Coupler> unlockedCouplers = new HashSet<Coupler>();

--- a/KnuckleCouplers.cs
+++ b/KnuckleCouplers.cs
@@ -21,18 +21,28 @@ namespace DvMod.ZCouplers
             CouplerType couplerType = Main.settings.couplerType.Value;
             hookPrefab = bundle.LoadAsset<GameObject>(couplerType.ToString());
             bundle.Unload(false);
+            ToggleBuffers(Main.settings.showBuffersWithKnuckles.Value);
         }
 
-        public static void RemoveBuffers()
+        public static void ToggleBuffers(bool visible)
         {
-            foreach (TrainCarLivery livery in Globals.G.Types.Liveries)
-            {
-                Transform[] children = livery.prefab.GetComponentsInChildren<Transform>();
-                foreach (Transform child in children)
-                    // Search for buffer pads, then buffer stems. Stems aren't named or placed consistently, so we have to generalize.
-                    if (child.name.StartsWith("Buffer_") || child.name.Replace("_", "").ToLowerInvariant().Contains("bufferstem"))
-                        child.gameObject.SetActive(false);
-            }
+            Main.DebugLog(() => $"Toggling buffer visibility {(visible ? "on" : "off")}");
+            // Modify prefabs for any new cars that are instantiated.
+            foreach (TrainCarLivery livery in Globals.G.Types.Liveries) 
+                ToggleBuffers(livery.prefab, visible);
+            // Modify existing cars so the setting can update in real-time.
+            if (CarSpawner.Instance == null) return;
+            foreach (TrainCar car in CarSpawner.Instance.allCars) 
+                ToggleBuffers(car.gameObject, visible);
+        }
+
+        private static void ToggleBuffers(GameObject root, bool visible)
+        {
+            MeshRenderer[] renderers = root.GetComponentsInChildren<MeshRenderer>();
+            foreach (MeshRenderer renderer in renderers)
+                // Search for buffer pads, then buffer stems. Stems aren't named or placed consistently, so we have to generalize.
+                if (renderer.name.StartsWith("Buffer_") || renderer.name.Replace("_", "").ToLowerInvariant().Contains("bufferstem"))
+                    renderer.enabled = visible;
         }
 
         private static readonly HashSet<Coupler> unlockedCouplers = new HashSet<Coupler>();

--- a/Main.cs
+++ b/Main.cs
@@ -26,7 +26,6 @@ namespace DvMod.ZCouplers
             // Force static initializer to execute and load asset bundle
             if (KnuckleCouplers.enabled)
             {
-                KnuckleCouplers.RemoveBuffers();
                 Logger.LogInfo("Loaded {settings.couplerType}");
             }
             // CCLIntegration.Initialize(DebugLog);

--- a/Main.cs
+++ b/Main.cs
@@ -26,6 +26,7 @@ namespace DvMod.ZCouplers
             // Force static initializer to execute and load asset bundle
             if (KnuckleCouplers.enabled)
             {
+                KnuckleCouplers.RemoveBuffers();
                 Logger.LogInfo("Loaded {settings.couplerType}");
             }
             // CCLIntegration.Initialize(DebugLog);

--- a/Settings.cs
+++ b/Settings.cs
@@ -18,6 +18,7 @@ namespace DvMod.ZCouplers
         public ConfigEntry<float> bufferSpringRate;
         public ConfigEntry<float> bufferDamperRate;
 
+        public ConfigEntry<bool> showBuffersWithKnuckles;
         public ConfigEntry<float> knuckleStrength;
         public ConfigEntry<float> drawgearSpringRate;
         public ConfigEntry<float> drawgearDamperRate;
@@ -37,6 +38,12 @@ namespace DvMod.ZCouplers
             bufferSpringRate = configFile.Bind("chain", "spring", 2f, new ConfigDescription("Compression spring rate", POSITIVE));
             bufferDamperRate = configFile.Bind("chain", "damper", 8f, new ConfigDescription("Compression damper rate", POSITIVE));
 
+            showBuffersWithKnuckles = configFile.Bind("knuckle", "showBuffers", false, "Whether to show buffers when knuckles are in use");
+            showBuffersWithKnuckles.SettingChanged += (sender, args) =>
+            {
+                if (KnuckleCouplers.enabled)
+                    KnuckleCouplers.ToggleBuffers(showBuffersWithKnuckles.Value);
+            };
             knuckleStrength = configFile.Bind("knuckle", "strength", 1.78f, new ConfigDescription("Knuckle strength (Mn)", POSITIVE));
             drawgearSpringRate = configFile.Bind("knuckle", "spring", 0.1f, new ConfigDescription("Compression spring rate", POSITIVE));
             drawgearDamperRate = configFile.Bind("knuckle", "damper", 100f, new ConfigDescription("Compression damper rate", POSITIVE));

--- a/ZCouplers.csproj
+++ b/ZCouplers.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <Reference Include="0Harmony"/>
     <Reference Include="Assembly-CSharp"/>
+    <Reference Include="DV.ThingTypes"/>
     <Reference Include="Assembly-CSharp-firstpass"/>
     <!-- <Reference Include="DVCustomCarLoader"/> -->
     <Reference Include="DV.BrakeSystem"/>


### PR DESCRIPTION
When the mod is loaded with knuckles enabled, all `TrainCarLivery`'s are searched for buffer pads and stems. If any are found, their GameObjects are disabled.

Since the name and location of buffer stems are inconsistent across rolling stock, the entire hierarchy is searched.

- Buffer pads are found by checking if the name starts with `Buffer_`, which seems consistent.
- Buffer stems around found by removing any underscores and converting to lowercase, then checking to see if the string contains `bufferstem`.