### PR TITLE
B99 Compatibility

### DIFF
--- a/Couplers.cs
+++ b/Couplers.cs
@@ -341,10 +341,19 @@ namespace DvMod.ZCouplers
 
             public static void Postfix(Coupler __instance)
             {
-                __instance.rigidCJ = compressionJoints[__instance];
-                compressionJoints.Remove(__instance);
-                __instance.jointCoroRigid = coros[__instance];
-                coros.Remove(__instance);
+                // Safely restore compression joint if it was stored
+                if (compressionJoints.TryGetValue(__instance, out var storedJoint))
+                {
+                    __instance.rigidCJ = storedJoint;
+                    compressionJoints.Remove(__instance);
+                }
+                
+                // Safely restore coroutine if it was stored
+                if (coros.TryGetValue(__instance, out var storedCoro))
+                {
+                    __instance.jointCoroRigid = storedCoro;
+                    coros.Remove(__instance);
+                }
             }
         }
 

--- a/Couplers.cs
+++ b/Couplers.cs
@@ -8,6 +8,17 @@ namespace DvMod.ZCouplers
 {
     public static class Couplers
     {
+        // Custom tension joint management
+        private static readonly Dictionary<Coupler, ConfigurableJoint> customTensionJoints = new Dictionary<Coupler, ConfigurableJoint>();
+        
+        // Track when joints were last created to prevent rapid recreation
+        private static readonly Dictionary<Coupler, float> lastJointCreationTime = new Dictionary<Coupler, float>();
+        private const float MinJointCreationInterval = 2.0f; // Seconds between joint creation attempts
+        
+        // Track when couplers were manually uncoupled to prevent immediate recoupling
+        private static readonly Dictionary<Coupler, float> lastUncouplingTime = new Dictionary<Coupler, float>();
+        private const float UncouplingCooldown = 5.0f; // Seconds before allowing recoupling after manual uncoupling
+        
         private const float ChainSpring = 2e7f; // ~1,200,000 lb/in
         private const float LooseChainLength = 1.1f;
         private const float TightChainLength = 1.0f;
@@ -21,12 +32,21 @@ namespace DvMod.ZCouplers
 
         private static void KillCouplingScanner(Coupler coupler)
         {
-            var scanner = GetScanner(coupler);
-            if (scanner?.masterCoro != null)
+            if (coupler == null)
+                return;
+                
+            try
             {
-                Main.DebugLog(() => $"{coupler.train.ID} {coupler.Position()}: killing masterCoro");
-                scanner.StopCoroutine(scanner.masterCoro);
-                scanner.masterCoro = null;
+                var scanner = GetScanner(coupler);
+                if (scanner?.masterCoro != null)
+                {
+                    scanner.StopCoroutine(scanner.masterCoro);
+                    scanner.masterCoro = null;
+                }
+            }
+            catch (System.Exception ex)
+            {
+                Main.DebugLog(() => $"Error killing coupling scanner: {ex.Message}");
             }
         }
 
@@ -34,11 +54,136 @@ namespace DvMod.ZCouplers
         {
             if (coupler == null)
                 return;
-            var scanner = GetScanner(coupler);
-            if (scanner != null && scanner.masterCoro == null && scanner.isActiveAndEnabled)
+                
+            try
             {
-                Main.DebugLog(() => $"{coupler.train.ID} {coupler.Position()}: restarting masterCoro");
-                scanner.masterCoro = scanner.StartCoroutine(scanner.MasterCoro());
+                var scanner = GetScanner(coupler);
+                if (scanner != null && scanner.masterCoro == null && scanner.isActiveAndEnabled)
+                {
+                    scanner.masterCoro = scanner.StartCoroutine(scanner.MasterCoro());
+                }
+            }
+            catch (System.Exception ex)
+            {
+                Main.DebugLog(() => $"Error restarting coupling scanner: {ex.Message}");
+            }
+        }
+        
+        private static void SeparateCarsAfterUncoupling(Coupler coupler1, Coupler coupler2)
+        {
+            if (coupler1?.train?.gameObject == null || coupler2?.train?.gameObject == null)
+                return;
+                
+            try
+            {
+                var rb1 = coupler1.train.GetComponent<Rigidbody>();
+                var rb2 = coupler2.train.GetComponent<Rigidbody>();
+                
+                if (rb1 != null && rb2 != null)
+                {
+                    // Calculate separation direction
+                    var direction = (coupler1.transform.position - coupler2.transform.position).normalized;
+                    var separationForce = 2000f; // Increased force significantly
+                    
+                    // Apply opposing forces to separate the cars
+                    rb1.AddForce(direction * separationForce, ForceMode.Impulse);
+                    rb2.AddForce(-direction * separationForce, ForceMode.Impulse);
+                    
+                    Main.DebugLog(() => $"Applied separation force between {coupler1.train.ID} and {coupler2.train.ID}");
+                }
+                
+                // Temporarily disable coupling scanners to prevent immediate recoupling
+                var scanner1 = GetScanner(coupler1);
+                var scanner2 = GetScanner(coupler2);
+                
+                if (scanner1 != null)
+                {
+                    scanner1.enabled = false;
+                    scanner1.StartCoroutine(ReEnableScanner(scanner1, coupler1.train.ID, 3.0f));
+                }
+                if (scanner2 != null)
+                {
+                    scanner2.enabled = false;
+                    scanner2.StartCoroutine(ReEnableScanner(scanner2, coupler2.train.ID, 3.0f));
+                }
+                
+            }
+            catch (System.Exception ex)
+            {
+                Main.DebugLog(() => $"Error separating cars after uncoupling: {ex.Message}");
+            }
+        }
+        
+        private static IEnumerator ReEnableScanner(CouplingScanner scanner, string trainId, float delay)
+        {
+            yield return new WaitForSeconds(delay);
+            
+            if (scanner != null)
+            {
+                scanner.enabled = true;
+                Main.DebugLog(() => $"Re-enabled coupling scanner for {trainId}");
+            }
+        }
+        
+        private static void DestroyAllJoints(Coupler coupler)
+        {
+            if (coupler?.train?.gameObject == null)
+                return;
+                
+            try
+            {
+                var trainCar = coupler.train;
+                Main.DebugLog(() => $"Destroying all joints on {trainCar.ID}");
+                
+                // Destroy ALL ConfigurableJoints on this car
+                var allJoints = trainCar.GetComponents<ConfigurableJoint>();
+                foreach (var joint in allJoints)
+                {
+                    if (joint != null)
+                        Component.Destroy(joint);
+                }
+                
+                // Destroy ALL FixedJoints on this car
+                var fixedJoints = trainCar.GetComponents<FixedJoint>();
+                foreach (var joint in fixedJoints)
+                {
+                    if (joint != null)
+                        Component.Destroy(joint);
+                }
+                
+                // Destroy ALL SpringJoints on this car
+                var springJoints = trainCar.GetComponents<SpringJoint>();
+                foreach (var joint in springJoints)
+                {
+                    if (joint != null)
+                        Component.Destroy(joint);
+                }
+                
+                // Destroy ALL HingeJoints on this car
+                var hingeJoints = trainCar.GetComponents<HingeJoint>();
+                foreach (var joint in hingeJoints)
+                {
+                    if (joint != null)
+                        Component.Destroy(joint);
+                }
+                
+                // Clear the rigidCJ and jointCoroRigid from both couplers on this car
+                if (trainCar.frontCoupler != null)
+                {
+                    trainCar.frontCoupler.rigidCJ = null;
+                    trainCar.frontCoupler.jointCoroRigid = null;
+                }
+                if (trainCar.rearCoupler != null)
+                {
+                    trainCar.rearCoupler.rigidCJ = null;
+                    trainCar.rearCoupler.jointCoroRigid = null;
+                }
+                
+                Main.DebugLog(() => $"Completed joint destruction for {trainCar.ID}");
+            }
+            catch (System.Exception ex)
+            {
+                Main.DebugLog(() => $"Error in nuclear joint cleanup: {ex.Message}");
             }
         }
 
@@ -53,10 +198,73 @@ namespace DvMod.ZCouplers
                     return true;
                 }
 
+                // Prevent joint creation during save loading to avoid physics instability
+                if (SaveManager.IsLoadingFromSave)
+                {
+                    Main.DebugLog(() => $"Skipping joint creation during save loading: {__instance.train.ID}");
+                    return true;
+                }
+
+                // Safety check: don't create joints if train is derailed or moving too fast
+                if (__instance.train.derailed || __instance.coupledTo?.train.derailed == true)
+                {
+                    Main.DebugLog(() => $"Skipping joint creation - train derailed: {__instance.train.ID}");
+                    return true;
+                }
+
+                // Safety check: don't create joints if cars are moving too fast (loading/teleporting)
+                var velocity1 = __instance.train.GetComponent<Rigidbody>()?.velocity.magnitude ?? 0f;
+                var velocity2 = __instance.coupledTo?.train.GetComponent<Rigidbody>()?.velocity.magnitude ?? 0f;
+                if (velocity1 > 5f || velocity2 > 5f)
+                {
+                    Main.DebugLog(() => $"Skipping joint creation - cars moving too fast: {__instance.train.ID} ({velocity1:F1} m/s) to {__instance.coupledTo?.train.ID} ({velocity2:F1} m/s)");
+                    return true;
+                }
+
+                // Safety check: don't create joints too frequently (prevent load/teleport spam)
+                var currentTime = Time.time;
+                if (lastJointCreationTime.TryGetValue(__instance, out var lastTime) && (currentTime - lastTime) < MinJointCreationInterval)
+                {
+                    Main.DebugLog(() => $"Skipping joint creation - too soon after last creation: {__instance.train.ID}");
+                    return true;
+                }
+                
+                // Safety check: don't recouple immediately after manual uncoupling
+                if (lastUncouplingTime.TryGetValue(__instance, out var lastUncoupling) && (currentTime - lastUncoupling) < UncouplingCooldown)
+                {
+                    Main.DebugLog(() => $"Skipping joint creation - uncoupling cooldown active: {__instance.train.ID} ({(UncouplingCooldown - (currentTime - lastUncoupling)):F1}s remaining)");
+                    return true;
+                }
+                if (__instance.coupledTo != null && lastUncouplingTime.TryGetValue(__instance.coupledTo, out var partnerLastUncoupling) && (currentTime - partnerLastUncoupling) < UncouplingCooldown)
+                {
+                    Main.DebugLog(() => $"Skipping joint creation - partner uncoupling cooldown active: {__instance.coupledTo.train.ID}");
+                    return true;
+                }
+
+                // Safety check: don't create joints if we already have custom tension joints
+                if (customTensionJoints.ContainsKey(__instance) || (__instance.coupledTo != null && customTensionJoints.ContainsKey(__instance.coupledTo)))
+                {
+                    Main.DebugLog(() => $"Skipping joint creation - joints already exist: {__instance.train.ID}");
+                    return false;
+                }
+
+                // Safety check: ensure we have a valid coupled partner
+                if (__instance.coupledTo == null)
+                {
+                    Main.DebugLog(() => $"Skipping joint creation - no coupled partner: {__instance.train.ID}");
+                    return true;
+                }
+
                 Main.DebugLog(() => $"Creating tension joint between {__instance.train.ID} and {__instance.coupledTo.train.ID}");
+                
+                // Record the time of joint creation
+                lastJointCreationTime[__instance] = currentTime;
+                lastJointCreationTime[__instance.coupledTo] = currentTime;
+                
                 CreateTensionJoint(__instance);
                 var breaker = __instance.gameObject.AddComponent<CouplerBreaker>();
-                breaker.joint = __instance.springyCJ;
+                if (customTensionJoints.TryGetValue(__instance, out var tensionJoint))
+                    breaker.joint = tensionJoint;
                 if (__instance.rigidCJ == null && __instance.coupledTo.rigidCJ == null)
                     CreateCompressionJoint(__instance, __instance.coupledTo);
                 KillCouplingScanner(__instance);
@@ -73,14 +281,62 @@ namespace DvMod.ZCouplers
 
             public static void Prefix(Coupler __instance)
             {
+                Main.DebugLog(() => $"Uncoupling {__instance.train.ID} from {__instance.coupledTo?.train.ID}");
+                
+                // Record uncoupling time to prevent immediate recoupling
+                var currentTime = Time.time;
+                lastUncouplingTime[__instance] = currentTime;
+                if (__instance.coupledTo != null)
+                    lastUncouplingTime[__instance.coupledTo] = currentTime;
+                
+                // Clear any pending coupler states for these cars
+                SaveManager.ClearPendingStatesForCar(__instance.train);
+                if (__instance.coupledTo?.train != null)
+                    SaveManager.ClearPendingStatesForCar(__instance.coupledTo.train);
+                
                 // Prevent Uncouple from destroying compression joint
                 compressionJoints[__instance] = __instance.rigidCJ;
                 __instance.rigidCJ = null;
                 coros[__instance] = __instance.jointCoroRigid;
                 __instance.jointCoroRigid = null;
 
+                // Destroy tension joints on both couplers - be more aggressive about cleanup
+                DestroyTensionJoint(__instance);
+                if (__instance.coupledTo != null)
+                {
+                    DestroyTensionJoint(__instance.coupledTo);
+                }
+
+                // Also destroy compression joints to ensure complete disconnection
+                DestroyCompressionJoint(__instance);
+                if (__instance.coupledTo != null)
+                {
+                    DestroyCompressionJoint(__instance.coupledTo);
+                }
+                
+                // Destroy all Unity joints on both cars to ensure complete physical disconnection
+                DestroyAllJoints(__instance);
+                if (__instance.coupledTo != null)
+                {
+                    DestroyAllJoints(__instance.coupledTo);
+                }
+
+                // Update knuckle coupler visual state to show uncoupled
+                KnuckleCouplers.UnlockCoupler(__instance, viaChainInteraction: false);
+                if (__instance.coupledTo != null)
+                {
+                    KnuckleCouplers.UnlockCoupler(__instance.coupledTo, viaChainInteraction: false);
+                }
+
+                // Restart coupling scanners and apply separation force
                 RestartCouplingScanner(__instance);
-                RestartCouplingScanner(__instance.coupledTo);
+                if (__instance.coupledTo != null)
+                {
+                    RestartCouplingScanner(__instance.coupledTo);
+                    SeparateCarsAfterUncoupling(__instance, __instance.coupledTo);
+                }
+                    
+                Main.DebugLog(() => $"Completed uncoupling cleanup for {__instance.train.ID}");
             }
 
             public static void Postfix(Coupler __instance)
@@ -101,6 +357,11 @@ namespace DvMod.ZCouplers
                 // remove pre-coupling joints, if any, before car is teleported
                 DestroyCompressionJoint(__instance.frontCoupler);
                 DestroyCompressionJoint(__instance.rearCoupler);
+                
+                // remove tension joints
+                DestroyTensionJoint(__instance.frontCoupler);
+                DestroyTensionJoint(__instance.rearCoupler);
+                
                 KillCouplingScanner(__instance.frontCoupler);
                 KillCouplingScanner(__instance.rearCoupler);
             }
@@ -111,17 +372,49 @@ namespace DvMod.ZCouplers
         {
             public static void Postfix(TrainCar trainCar)
             {
-                Main.DebugLog(() => "TrainCar.PrepareTrainCarForDeleting.Postfix");
-                // remove pre-coupling joints, if any
-                DestroyCompressionJoint(trainCar.frontCoupler);
-                DestroyCompressionJoint(trainCar.rearCoupler);
-                KillCouplingScanner(trainCar.frontCoupler);
-                KillCouplingScanner(trainCar.rearCoupler);
+                try
+                {
+                    if (trainCar == null)
+                        return;
+                        
+                    Main.DebugLog(() => $"TrainCar.PrepareTrainCarForDeleting.Postfix for {trainCar.ID}");
+                    
+                    // Safely remove joints - check for null and validity before cleanup
+                    SafeCleanupCoupler(trainCar.frontCoupler);
+                    SafeCleanupCoupler(trainCar.rearCoupler);
+                }
+                catch (System.Exception ex)
+                {
+                    Main.DebugLog(() => $"Error during car deletion cleanup: {ex.Message}");
+                    // Don't rethrow - let the game continue its deletion process
+                }
+            }
+            
+            private static void SafeCleanupCoupler(Coupler coupler)
+            {
+                if (coupler == null || coupler.gameObject == null)
+                    return;
+                    
+                try
+                {
+                    // Only cleanup if the objects are still valid
+                    DestroyCompressionJoint(coupler);
+                    DestroyTensionJoint(coupler);
+                    KillCouplingScanner(coupler);
+                }
+                catch (System.Exception ex)
+                {
+                    Main.DebugLog(() => $"Error cleaning up coupler: {ex.Message}");
+                }
             }
         }
 
         private static void CreateTensionJoint(Coupler coupler)
         {
+            // Enhanced logging for tension joint creation
+            var coupledTo = coupler.coupledTo;
+            Main.DebugLog(() => $"TENSION JOINT: Creating for {coupler.train.ID} {coupler.Position()} -> {coupledTo?.train.ID} {coupledTo?.Position()}");
+            
             var anchorOffset =  Vector3.forward * TightChainLength * (coupler.isFrontCoupler ? -1f : 1f);
 
             var cj = coupler.train.gameObject.AddComponent<ConfigurableJoint>();
@@ -151,55 +444,34 @@ namespace DvMod.ZCouplers
             cj.breakForce = float.PositiveInfinity;
             cj.breakTorque = float.PositiveInfinity;
 
-            coupler.springyCJ = cj;
+            // Store tension joint
+            customTensionJoints[coupler] = cj;
+            Main.DebugLog(() => $"TENSION JOINT: Created successfully for {coupler.train.ID} {coupler.Position()}, total tension joints: {customTensionJoints.Count}");
+            
             if (!LooseChain.enabled)
                 TightenChain(coupler);
         }
 
         public static void TightenChain(Coupler coupler)
         {
-            if (coupler.springyCJ == null)
+            if (!customTensionJoints.TryGetValue(coupler, out var tensionJoint))
             {
-                if (coupler.coupledTo?.springyCJ != null)
+                if (coupler.coupledTo != null && customTensionJoints.ContainsKey(coupler.coupledTo))
                     TightenChain(coupler.coupledTo);
                 return;
             }
-            if (coupler.jointCoroSpringy != null)
-                coupler.StopCoroutine(coupler.jointCoroSpringy);
-            coupler.jointCoroSpringy = coupler.StartCoroutine(TightenChainCoro(coupler.springyCJ));
-        }
-
-        private static IEnumerator TightenChainCoro(ConfigurableJoint cj)
-        {
-            while (cj.linearLimit.limit > TightChainLength)
-            {
-                yield return WaitFor.FixedUpdate;
-                var tightenAmount = Time.deltaTime * TightenSpeed;
-                cj.linearLimit = new SoftJointLimit { limit = Mathf.Max(TightChainLength, cj.linearLimit.limit - tightenAmount) };
-            }
+            tensionJoint.linearLimit = new SoftJointLimit { limit = TightChainLength };
         }
 
         public static void LoosenChain(Coupler coupler)
         {
-            if (coupler.springyCJ == null)
+            if (!customTensionJoints.TryGetValue(coupler, out var tensionJoint))
             {
-                if (coupler.coupledTo?.springyCJ != null)
+                if (coupler.coupledTo != null && customTensionJoints.ContainsKey(coupler.coupledTo))
                     LoosenChain(coupler.coupledTo);
                 return;
             }
-            if (coupler.jointCoroSpringy != null)
-                coupler.StopCoroutine(coupler.jointCoroSpringy);
-            coupler.jointCoroSpringy = coupler.StartCoroutine(LoosenChainCoro(coupler.springyCJ));
-        }
-
-        private static IEnumerator LoosenChainCoro(ConfigurableJoint cj)
-        {
-            while (cj.linearLimit.limit < LooseChainLength)
-            {
-                yield return WaitFor.FixedUpdate;
-                var tightenAmount = Time.deltaTime * TightenSpeed;
-                cj.linearLimit = new SoftJointLimit { limit = Mathf.Min(LooseChainLength, cj.linearLimit.limit + tightenAmount) };
-            }
+            tensionJoint.linearLimit = new SoftJointLimit { limit = LooseChainLength };
         }
 
         // Ensure CouplingScanners start active
@@ -386,25 +658,124 @@ namespace DvMod.ZCouplers
 
         private static void DestroyCompressionJoint(Coupler coupler)
         {
-            if (!bufferJoints.TryGetValue(coupler, out var result))
+            if (coupler == null || !bufferJoints.TryGetValue(coupler, out var result))
                 return;
 
-            Main.DebugLog(() => $"Destroying compression joint between {TrainCar.Resolve(coupler.gameObject)?.ID} and {TrainCar.Resolve(result.otherCoupler.gameObject)?.ID}");
-            Component.Destroy(result.joint);
-
-            foreach (var c in new Coupler[]{ coupler, result.otherCoupler })
+            try
             {
-                if (c.jointCoroRigid != null)
-                {
-                    c.StopCoroutine(c.jointCoroRigid);
-                    c.jointCoroRigid = null;
-                }
-                Component.Destroy(c.rigidCJ);
-                c.rigidCJ = null;
-            }
+                Main.DebugLog(() => $"Destroying compression joint between {TrainCar.Resolve(coupler.gameObject)?.ID} and {TrainCar.Resolve(result.otherCoupler.gameObject)?.ID}");
+                
+                // Safely destroy the joint
+                if (result.joint != null)
+                    Component.Destroy(result.joint);
 
-            bufferJoints.Remove(coupler);
-            bufferJoints.Remove(result.otherCoupler);
+                foreach (var c in new Coupler[]{ coupler, result.otherCoupler })
+                {
+                    if (c != null)
+                    {
+                        try
+                        {
+                            if (c.jointCoroRigid != null)
+                            {
+                                c.StopCoroutine(c.jointCoroRigid);
+                                c.jointCoroRigid = null;
+                            }
+                            if (c.rigidCJ != null)
+                            {
+                                Component.Destroy(c.rigidCJ);
+                                c.rigidCJ = null;
+                            }
+                        }
+                        catch (System.Exception ex)
+                        {
+                            Main.DebugLog(() => $"Error cleaning up coupler {c?.train?.ID}: {ex.Message}");
+                        }
+                    }
+                }
+
+                bufferJoints.Remove(coupler);
+                bufferJoints.Remove(result.otherCoupler);
+            }
+            catch (System.Exception ex)
+            {
+                Main.DebugLog(() => $"Error destroying compression joint: {ex.Message}");
+                // Still try to remove from dictionary to prevent memory leaks
+                bufferJoints.Remove(coupler);
+                if (result.otherCoupler != null)
+                    bufferJoints.Remove(result.otherCoupler);
+            }
+        }
+
+        private static void DestroyTensionJoint(Coupler coupler)
+        {
+            if (coupler == null)
+                return;
+                
+            try
+            {
+                if (customTensionJoints.TryGetValue(coupler, out var tensionJoint))
+                {
+                    if (tensionJoint != null)
+                    {
+                        Main.DebugLog(() => $"TENSION JOINT: Destroying for {coupler.train.ID} {coupler.Position()}");
+                        UnityEngine.Object.Destroy(tensionJoint);
+                    }
+                    customTensionJoints.Remove(coupler);
+                    lastJointCreationTime.Remove(coupler); // Clean up timing tracking
+                    Main.DebugLog(() => $"TENSION JOINT: Destroyed and removed from dictionary for {coupler.train.ID} {coupler.Position()}, remaining joints: {customTensionJoints.Count}");
+                }
+                else
+                {
+                    Main.DebugLog(() => $"TENSION JOINT: No tension joint found to destroy for {coupler.train.ID} {coupler.Position()}");
+                }
+            }
+            catch (System.Exception ex)
+            {
+                Main.DebugLog(() => $"Error destroying tension joint: {ex.Message}");
+                // Still try to remove from dictionaries to prevent memory leaks
+                customTensionJoints.Remove(coupler);
+                lastJointCreationTime.Remove(coupler);
+            }
+        }
+
+        // Public method to check if tension joint exists
+        public static bool HasTensionJoint(Coupler coupler)
+        {
+            return coupler != null && customTensionJoints.ContainsKey(coupler);
+        }
+
+        // Public method to force create tension joint (used by SaveManager)
+        public static void ForceCreateTensionJoint(Coupler coupler)
+        {
+            if (coupler == null || !coupler.IsCoupled() || coupler.coupledTo == null)
+                return;
+                
+            if (customTensionJoints.ContainsKey(coupler))
+                return; // Already exists
+                
+            Main.DebugLog(() => $"FORCE CREATING tension joint for {coupler.train.ID} {coupler.Position()} -> {coupler.coupledTo.train.ID} {coupler.coupledTo.Position()}");
+            CreateTensionJoint(coupler);
+            
+            // Also create compression joint if needed
+            if (coupler.rigidCJ == null && coupler.coupledTo.rigidCJ == null)
+                CreateCompressionJoint(coupler, coupler.coupledTo);
+        }
+
+        // Public method to check joint states for debugging
+        public static void LogJointStates(string context)
+        {
+            Main.DebugLog(() => $"JOINT STATES ({context}): Tension joints: {customTensionJoints.Count}");
+            foreach (var kvp in customTensionJoints.ToList())
+            {
+                var coupler = kvp.Key;
+                var joint = kvp.Value;
+                if (coupler?.train != null && joint != null)
+                {
+                    var distance = joint.connectedBody != null ? 
+                        Vector3.Distance(coupler.transform.position, joint.connectedBody.transform.TransformPoint(joint.connectedAnchor)) : 0f;
+                    Main.DebugLog(() => $"  {coupler.train.ID} {coupler.Position()} -> {coupler.coupledTo?.train.ID}, distance: {distance:F2}m, joint valid: {joint != null}");
+                }
+            }
         }
 
         private static Vector3 JointDelta(Joint joint, bool isFrontCoupler)

--- a/Couplers.cs
+++ b/Couplers.cs
@@ -76,21 +76,6 @@ namespace DvMod.ZCouplers
                 
             try
             {
-                var rb1 = coupler1.train.GetComponent<Rigidbody>();
-                var rb2 = coupler2.train.GetComponent<Rigidbody>();
-                
-                if (rb1 != null && rb2 != null)
-                {
-                    // Calculate separation direction
-                    var direction = (coupler1.transform.position - coupler2.transform.position).normalized;
-                    var separationForce = 2000f; // Increased force significantly
-                    
-                    // Apply opposing forces to separate the cars
-                    rb1.AddForce(direction * separationForce, ForceMode.Impulse);
-                    rb2.AddForce(-direction * separationForce, ForceMode.Impulse);
-                    
-                    Main.DebugLog(() => $"Applied separation force between {coupler1.train.ID} and {coupler2.train.ID}");
-                }
                 
                 // Temporarily disable coupling scanners to prevent immediate recoupling
                 var scanner1 = GetScanner(coupler1);
@@ -110,7 +95,7 @@ namespace DvMod.ZCouplers
             }
             catch (System.Exception ex)
             {
-                Main.DebugLog(() => $"Error separating cars after uncoupling: {ex.Message}");
+                Main.DebugLog(() => $"Error in uncoupling cleanup: {ex.Message}");
             }
         }
         

--- a/KnuckleCouplers.cs
+++ b/KnuckleCouplers.cs
@@ -12,7 +12,7 @@ namespace DvMod.ZCouplers
     public static class KnuckleCouplers
     {
         public static readonly bool enabled = Main.settings.couplerType != CouplerType.BufferAndChain;
-        private static readonly GameObject hookPrefab;
+        private static readonly GameObject? hookPrefab;
 
         static KnuckleCouplers()
         {
@@ -199,6 +199,12 @@ namespace DvMod.ZCouplers
             pivot.transform.localPosition = new Vector3(0, HeightOffset, -PivotLength);
             pivot.transform.parent = coupler.train.interior;
             pivots.Add(chainScript, pivot.transform);
+
+            if (hookPrefab == null)
+            {
+                Main.DebugLog(() => "Hook prefab is null, cannot create knuckle coupler hook");
+                return;
+            }
 
             var hook = GameObject.Instantiate(hookPrefab);
             hook.SetActive(false); // defer Awake() until all components are added and initialized

--- a/KnuckleCouplers.cs
+++ b/KnuckleCouplers.cs
@@ -269,6 +269,52 @@ namespace DvMod.ZCouplers
                 infoArea.infoType = KnuckleCouplerUnlock;
         }
 
+        // Update visual state only without triggering actual uncoupling
+        public static void UpdateCouplerVisualState(Coupler coupler, bool locked)
+        {
+            if (!enabled)
+                return;
+                
+            var chainScript = coupler.visualCoupler?.chainAdapter?.chainScript;
+            if (chainScript == null)
+                return;
+                
+            if (locked)
+            {
+                // Coupler should show as locked (ready to unlock)
+                unlockedCouplers.Remove(coupler);
+                if (GetPivot(chainScript)?.Find("hook")?.GetComponent<InfoArea>() is InfoArea infoArea)
+                    infoArea.infoType = KnuckleCouplerUnlock;
+            }
+            else
+            {
+                // Coupler should show as unlocked (ready to couple)
+                unlockedCouplers.Add(coupler);
+                if (GetPivot(chainScript)?.Find("hook")?.GetComponent<InfoArea>() is InfoArea infoArea)
+                    infoArea.infoType = KnuckleCouplerLock;
+                    
+                // Manually trigger visual disconnection for knuckle couplers
+                var pivot = GetPivot(chainScript);
+                if (pivot != null)
+                {
+                    pivot.localEulerAngles = coupler.transform.localEulerAngles;
+                    var hook = pivot.Find("hook");
+                    if (hook != null)
+                    {
+                        hook.localPosition = PivotLength * Vector3.forward;
+                        Main.DebugLog(() => $"Reset knuckle coupler hook position for {coupler.train.ID} {coupler.Position()}");
+                    }
+                }
+                
+                // Clear the attached reference if it exists
+                if (chainScript.attachedTo != null)
+                {
+                    chainScript.attachedTo.attachedTo = null;
+                    chainScript.attachedTo = null;
+                }
+            }
+        }
+
         private static void OnButtonPressed(ChainCouplerInteraction chainScript)
         {
             var coupler = chainScript.couplerAdapter.coupler;
@@ -366,6 +412,22 @@ namespace DvMod.ZCouplers
             public static bool Prefix()
             {
                 return !enabled;
+            }
+        }
+
+        [HarmonyPatch(typeof(ChainCouplerCouplerAdapter), nameof(ChainCouplerCouplerAdapter.OnCoupled))]
+        public static class OnCoupledPatch
+        {
+            public static void Postfix(ChainCouplerCouplerAdapter __instance, CoupleEventArgs e)
+            {
+                if (!enabled)
+                    return;
+                    
+                Main.DebugLog(() => $"Knuckle OnCoupled: {e.thisCoupler.train.ID}<=>{e.otherCoupler.train.ID},viaChain={e.viaChainInteraction}");
+                
+                // Update knuckle coupler visual state to show coupled (locked) without triggering uncoupling
+                UpdateCouplerVisualState(e.thisCoupler, locked: true);
+                UpdateCouplerVisualState(e.otherCoupler, locked: true);
             }
         }
 

--- a/LooseChain.cs
+++ b/LooseChain.cs
@@ -33,14 +33,14 @@ namespace DvMod.ZCouplers
             }
         }
 
-        [HarmonyPatch(typeof(ChainCouplerInteraction), nameof(ChainCouplerInteraction.Update_Attached_Loose))]
-        public static class UpdateAttachedLoosePatch
-        {
-            public static bool Prefix()
-            {
-                return !enabled;
-            }
-        }
+        //[HarmonyPatch(typeof(ChainCouplerInteraction), nameof(ChainCouplerInteraction.Update_Attached_Loose))]
+        //public static class UpdateAttachedLoosePatch
+        //{
+        //    public static bool Prefix()
+        //    {
+        //        return !enabled;
+        //    }
+        //}
 
         [HarmonyPatch(typeof(ChainCouplerInteraction), nameof(ChainCouplerInteraction.Entry_Attached_Tight))]
         public static class EntryAttachedTightPatch
@@ -135,7 +135,7 @@ namespace DvMod.ZCouplers
                         __result = ChainCouplerInteraction.State.Other_Attached_Parked;
                         return false;
                     }
-                    if (__instance.couplerAdapter.coupler.springyCJ != null)
+                    if (looseCouplers.Contains(__instance.couplerAdapter.coupler))
                     {
                         __result = looseCouplers.Contains(__instance.couplerAdapter.coupler)
                             ? ChainCouplerInteraction.State.Attached_Loose
@@ -166,6 +166,11 @@ namespace DvMod.ZCouplers
                 if (!enabled)
                     return true;
                 Main.DebugLog(() => $"OnCoupled: {e.thisCoupler.train.ID}<=>{e.otherCoupler.train.ID},viaChain={e.viaChainInteraction}");
+                
+                // Update knuckle coupler visual state to show coupled (locked)
+                KnuckleCouplers.ReadyCoupler(e.thisCoupler);
+                KnuckleCouplers.ReadyCoupler(e.otherCoupler);
+                
                 if (!e.viaChainInteraction)
                 {
                     __instance.chainScript.CoupledExternally(e.otherCoupler);

--- a/Main.cs
+++ b/Main.cs
@@ -17,11 +17,21 @@ namespace DvMod.ZCouplers
             try
             {
                 Settings? loaded = Settings.Load<Settings>(modEntry);
-                settings = loaded.version == modEntry.Info.Version ? loaded : new Settings();
+                if (loaded != null)
+                {
+                    settings = loaded;
+                    modEntry.Logger.Log("Loaded existing settings");
+                }
+                else
+                {
+                    settings = new Settings();
+                    modEntry.Logger.Log("Created new settings (no existing file)");
+                }
             }
-            catch
+            catch (Exception ex)
             {
                 settings = new Settings();
+                modEntry.Logger.Log($"Failed to load settings, using defaults: {ex.Message}");
             }
 
             modEntry.OnGUI = settings.Draw;
@@ -33,7 +43,7 @@ namespace DvMod.ZCouplers
 
             // Force static initializer to execute and load asset bundle
             if (KnuckleCouplers.enabled)
-                mod.Logger.Log("Loaded {settings.couplerType}");
+                mod.Logger.Log($"Loaded {settings.couplerType}");
 
             // CCLIntegration.Initialize();
 

--- a/SaveManager.cs
+++ b/SaveManager.cs
@@ -1,5 +1,8 @@
 using HarmonyLib;
 using Newtonsoft.Json.Linq;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
 
 namespace DvMod.ZCouplers
 {
@@ -8,15 +11,36 @@ namespace DvMod.ZCouplers
         private const string SaveKey = "DvMod.ZCouplers";
         private const string FrontCouplerLockedKey = "frontCouplerLocked";
         private const string RearCouplerLockedKey = "rearCouplerLocked";
+        
+        // Store coupler states that need to be applied after physics stabilizes
+        private static readonly Dictionary<TrainCar, (bool frontLocked, bool rearLocked)> pendingCouplerStates = 
+            new Dictionary<TrainCar, (bool, bool)>();
+        private static bool isLoadingFromSave = false;
+        private static float saveLoadStartTime = 0f;
+        private const float SaveLoadGracePeriod = 5.0f; // 5 seconds after first car loaded
 
         [HarmonyPatch(typeof(CarsSaveManager), nameof(CarsSaveManager.GetCarSaveData))]
         public static class GetCarSaveDataPatch
         {
             public static void Postfix(TrainCar car, JObject __result)
             {
-                __result[SaveKey] = new JObject(
-                    new JProperty(FrontCouplerLockedKey, KnuckleCouplers.IsReadyToCouple(car.frontCoupler)),
-                    new JProperty(RearCouplerLockedKey, KnuckleCouplers.IsReadyToCouple(car.rearCoupler)));
+                try
+                {
+                    // Only save coupler data if knuckle couplers are enabled
+                    if (KnuckleCouplers.enabled && car?.frontCoupler != null && car?.rearCoupler != null)
+                    {
+                        __result[SaveKey] = new JObject(
+                            new JProperty(FrontCouplerLockedKey, KnuckleCouplers.IsReadyToCouple(car.frontCoupler)),
+                            new JProperty(RearCouplerLockedKey, KnuckleCouplers.IsReadyToCouple(car.rearCoupler)));
+                        
+                        Main.DebugLog(() => $"Saved coupler states for car {car.ID}");
+                    }
+                }
+                catch (System.Exception ex)
+                {
+                    Main.DebugLog(() => $"Error saving coupler data for car {car?.ID}: {ex.Message}");
+                    // Don't add any save data if there's an error
+                }
             }
         }
 
@@ -25,21 +49,260 @@ namespace DvMod.ZCouplers
         {
             public static void Postfix(JObject carData, RailTrack[] tracks, TrainCar __result)
             {
-                static void SetupCoupler(Coupler coupler, bool locked)
+                try
                 {
-                    if (locked)
-                        KnuckleCouplers.ReadyCoupler(coupler);
+                    // Only set loading state on the first car to avoid constantly resetting it
+                    if (pendingCouplerStates.Count == 0)
+                    {
+                        isLoadingFromSave = true;
+                        saveLoadStartTime = Time.time;
+                        Main.DebugLog(() => "Started save loading process");
+                    }
+                    
+                    // Store coupler states for deferred application
+                    if (carData?.TryGetValue(SaveKey, out var data) == true && data is JObject obj)
+                    {
+                        bool frontLocked = obj.TryGetValue(FrontCouplerLockedKey, out var frontToken) && frontToken.Value<bool>();
+                        bool rearLocked = obj.TryGetValue(RearCouplerLockedKey, out var rearToken) && rearToken.Value<bool>();
+                        
+                        pendingCouplerStates[__result] = (frontLocked, rearLocked);
+                        Main.DebugLog(() => $"Stored pending coupler states for car {__result.ID}: front={frontLocked}, rear={rearLocked}");
+                    }
                     else
-                        KnuckleCouplers.UnlockCoupler(coupler, true);
+                    {
+                        // No save data - use defaults (unlocked for knuckle couplers)
+                        if (KnuckleCouplers.enabled)
+                        {
+                            pendingCouplerStates[__result] = (false, false);
+                            Main.DebugLog(() => $"No coupler save data for car {__result.ID}, will use defaults");
+                        }
+                    }
+                    
+                    // Start deferred application only for the first car
+                    if (pendingCouplerStates.Count == 1)
+                    {
+                        __result.StartCoroutine(TriggerDeferredApplicationCoroutine());
+                    }
                 }
-
-                if ((carData?.TryGetValue(SaveKey, out var data) ?? false) && data is JObject obj)
+                catch (System.Exception ex)
                 {
-                    if (obj.TryGetValue(FrontCouplerLockedKey, out var frontLocked))
-                        SetupCoupler(__result.frontCoupler, frontLocked.Value<bool>());
-                    if (obj.TryGetValue(RearCouplerLockedKey, out var rearLocked))
-                        SetupCoupler(__result.rearCoupler, rearLocked.Value<bool>());
+                    Main.DebugLog(() => $"Error processing coupler save data for car {__result.ID}: {ex.Message}");
+                    // Use safe defaults
+                    if (KnuckleCouplers.enabled)
+                        pendingCouplerStates[__result] = (false, false);
                 }
+            }
+        }
+        
+        private static IEnumerator TriggerDeferredApplicationCoroutine()
+        {
+            // Wait a bit for all cars to be loaded
+            yield return new WaitForSeconds(2.0f);
+            
+            // Reset the loading state to allow normal joint creation
+            isLoadingFromSave = false;
+            Main.DebugLog(() => "Save loading period ended - normal joint creation restored");
+            
+            // Trigger deferred application
+            StartDeferredCouplerApplication();
+        }
+        
+        private static void ApplyPendingStatesImmediately()
+        {
+            Main.DebugLog(() => "Applying pending coupler states immediately as fallback");
+            
+            foreach (var kvp in pendingCouplerStates)
+            {
+                var car = kvp.Key;
+                var (frontLocked, rearLocked) = kvp.Value;
+                
+                if (car != null && car.gameObject != null)
+                {
+                    try
+                    {
+                        ApplyCouplerState(car.frontCoupler, frontLocked);
+                        ApplyCouplerState(car.rearCoupler, rearLocked);
+                        Main.DebugLog(() => $"Applied coupler states for car {car.ID}: front={frontLocked}, rear={rearLocked}");
+                    }
+                    catch (System.Exception ex)
+                    {
+                        Main.DebugLog(() => $"Error applying coupler states for car {car.ID}: {ex.Message}");
+                    }
+                }
+            }
+            
+            pendingCouplerStates.Clear();
+            isLoadingFromSave = false;
+            Main.DebugLog(() => "Immediate application completed - normal joint creation restored");
+        }
+        
+        // Simple deferred application system using MonoBehaviour
+        public static void StartDeferredCouplerApplication()
+        {
+            if (pendingCouplerStates.Count > 0)
+            {
+                Main.DebugLog(() => $"Starting deferred application of {pendingCouplerStates.Count} coupler states");
+                
+                // Try multiple GameObject names to find a suitable host
+                GameObject? host = null;
+                string[] possibleHosts = { "GameManager", "WorldMover", "Player", "PlayerManager", "CarSpawner" };
+                
+                foreach (string hostName in possibleHosts)
+                {
+                    host = GameObject.Find(hostName);
+                    if (host != null)
+                    {
+                        Main.DebugLog(() => $"Found host GameObject: {hostName}");
+                        break;
+                    }
+                }
+                
+                // If we can't find any specific GameObject, create our own
+                if (host == null)
+                {
+                    host = new GameObject("ZCouplers_DeferredApplier");
+                    UnityEngine.Object.DontDestroyOnLoad(host);
+                    Main.DebugLog(() => "Created dedicated host GameObject for deferred application");
+                }
+                
+                if (host != null)
+                {
+                    var deferredApplier = host.AddComponent<DeferredCouplerApplier>();
+                    deferredApplier.Initialize(pendingCouplerStates);
+                    pendingCouplerStates.Clear();
+                }
+                else
+                {
+                    Main.DebugLog(() => "Could not create host for deferred application - applying immediately");
+                    // Fallback: apply immediately if we can't create a host
+                    ApplyPendingStatesImmediately();
+                }
+            }
+        }
+        
+        private static void ApplyCouplerState(Coupler coupler, bool locked)
+        {
+            if (coupler == null)
+                return;
+                
+            Main.DebugLog(() => $"Applying coupler state for {coupler.train.ID} {coupler.Position()}: locked={locked}, currently coupled={coupler.IsCoupled()}");
+                
+            if (locked)
+            {
+                // If should be locked but not currently coupled, this indicates a problem
+                if (!coupler.IsCoupled())
+                {
+                    Main.DebugLog(() => $"WARNING: {coupler.train.ID} {coupler.Position()} should be locked but is not coupled - save state inconsistency");
+                }
+                KnuckleCouplers.ReadyCoupler(coupler);
+            }
+            else
+            {
+                // Only unlock if currently coupled
+                if (coupler.IsCoupled())
+                {
+                    KnuckleCouplers.UnlockCoupler(coupler, true);
+                }
+                else
+                {
+                    Main.DebugLog(() => $"Coupler {coupler.train.ID} {coupler.Position()} should be unlocked and is already uncoupled - correct state");
+                }
+            }
+        }
+        
+        // Prevent joint creation during save loading
+        public static bool IsLoadingFromSave => isLoadingFromSave && (Time.time - saveLoadStartTime) < SaveLoadGracePeriod;
+        
+        // Clear pending states for manually uncoupled cars
+        public static void ClearPendingStatesForCar(TrainCar car)
+        {
+            if (pendingCouplerStates.ContainsKey(car))
+            {
+                pendingCouplerStates.Remove(car);
+                Main.DebugLog(() => $"Cleared pending coupler states for manually uncoupled car {car.ID}");
+            }
+        }
+        
+        private static void CreateMissingTensionJoints(Coupler coupler)
+        {
+            if (coupler == null || !coupler.IsCoupled() || coupler.coupledTo == null)
+                return;
+                
+            // Check if tension joint already exists
+            if (Couplers.HasTensionJoint(coupler))
+            {
+                Main.DebugLog(() => $"Tension joint already exists for {coupler.train.ID} {coupler.Position()}");
+                return;
+            }
+            
+            // Create tension joint using the Couplers system
+            Main.DebugLog(() => $"Creating missing tension joint for {coupler.train.ID} {coupler.Position()} -> {coupler.coupledTo.train.ID} {coupler.coupledTo.Position()}");
+            
+            try
+            {
+                Couplers.ForceCreateTensionJoint(coupler);
+            }
+            catch (System.Exception ex)
+            {
+                Main.DebugLog(() => $"Error creating tension joint for {coupler.train.ID}: {ex.Message}");
+            }
+        }
+
+        // Component to handle deferred coupler state application
+
+        public class DeferredCouplerApplier : MonoBehaviour
+        {
+            private Dictionary<TrainCar, (bool frontLocked, bool rearLocked)>? statesToApply;
+            
+            public void Initialize(Dictionary<TrainCar, (bool frontLocked, bool rearLocked)> states)
+            {
+                statesToApply = new Dictionary<TrainCar, (bool, bool)>(states);
+                StartCoroutine(ApplyStatesAfterDelay());
+            }
+            
+            private IEnumerator ApplyStatesAfterDelay()
+            {
+                // Wait for physics to stabilize
+                yield return new WaitForSeconds(3.0f);
+                
+                Main.DebugLog(() => "Applying deferred coupler states after physics stabilization");
+                
+                if (statesToApply != null)
+                {
+                    foreach (var kvp in statesToApply)
+                    {
+                        var car = kvp.Key;
+                        var (frontLocked, rearLocked) = kvp.Value;
+                        
+                        if (car != null && car.gameObject != null)
+                        {
+                            try
+                            {
+                                SaveManager.ApplyCouplerState(car.frontCoupler, frontLocked);
+                                SaveManager.ApplyCouplerState(car.rearCoupler, rearLocked);
+                                
+                                // Create missing tension joints for coupled cars
+                                SaveManager.CreateMissingTensionJoints(car.frontCoupler);
+                                SaveManager.CreateMissingTensionJoints(car.rearCoupler);
+                                
+                                Main.DebugLog(() => $"Applied coupler states for car {car.ID}: front={frontLocked}, rear={rearLocked}");
+                            }
+                            catch (System.Exception ex)
+                            {
+                                Main.DebugLog(() => $"Error applying coupler states for car {car.ID}: {ex.Message}");
+                            }
+                        }
+                    }
+                }
+                
+                Main.DebugLog(() => "Finished applying all deferred coupler states");
+                
+                // Ensure loading state is reset
+                SaveManager.isLoadingFromSave = false;
+                Main.DebugLog(() => "Deferred application completed - normal joint creation restored");
+                
+                // Self-destruct after completion
+                Destroy(this);
             }
         }
     }

--- a/SaveManager.cs
+++ b/SaveManager.cs
@@ -194,19 +194,14 @@ namespace DvMod.ZCouplers
                 {
                     Main.DebugLog(() => $"WARNING: {coupler.train.ID} {coupler.Position()} should be locked but is not coupled - save state inconsistency");
                 }
-                KnuckleCouplers.ReadyCoupler(coupler);
+                // Use visual state update only - don't trigger actual coupling/uncoupling during save loading
+                KnuckleCouplers.UpdateCouplerVisualState(coupler, locked: true);
             }
             else
             {
-                // Only unlock if currently coupled
-                if (coupler.IsCoupled())
-                {
-                    KnuckleCouplers.UnlockCoupler(coupler, true);
-                }
-                else
-                {
-                    Main.DebugLog(() => $"Coupler {coupler.train.ID} {coupler.Position()} should be unlocked and is already uncoupled - correct state");
-                }
+                // Update visual state to show unlocked without triggering actual uncoupling
+                KnuckleCouplers.UpdateCouplerVisualState(coupler, locked: false);
+                Main.DebugLog(() => $"Set coupler {coupler.train.ID} {coupler.Position()} visual state to unlocked");
             }
         }
         

--- a/ZCouplers.csproj
+++ b/ZCouplers.csproj
@@ -28,6 +28,8 @@
     <!-- <Reference Include="DVCustomCarLoader"/> -->
     <Reference Include="DV.BrakeSystem"/>
     <Reference Include="DV.Utils"/>
+    <Reference Include="DV.CabControls.Spec"/>
+    <Reference Include="DV.RailTrack"/>
     <Reference Include="Newtonsoft.Json"/>
     <Reference Include="RootMotion"/>
     <Reference Include="Stateless"/>


### PR DESCRIPTION
I had a long night and tried to patch the mod so that we can use it in B99:
* Added null checks for `hookPrefab` in `KnuckleCouplers.cs` to prevent errors when the prefab is not initialized
* Updated the visual state of knuckle couplers to show as "coupled" (locked) during coupling events. Otherwise the model would glitch out.
* Added new project references for `DV.CabControls.Spec` and `DV.RailTrack` for B99
* Commented out unused Harmony patch `UpdateAttachedLoosePatch` in `LooseChain.cs`
* The Wagons would glitch after loading and fly around so I had to change the loading order and deferr it

While I was patching, I stumbled on following errors and fixed them:
* Sometimes saving and loading would result in a "Deleting all cars/jobs so game state is clean!" error
* UMM Settings got reset after every restart

I tested it myself in a Sandbox world and it seems to work fine except "Buffer and Chain". I don't know why but UMM wants a restart after you select them even if you just restarted. Maybe removing this option would be an Idea? They could just disable the mod if they want Chains back