### PR TITLE
Preserve DE6 slug hose hardware

### DIFF
--- a/ZCouplers/Visuals/HookManager.cs
+++ b/ZCouplers/Visuals/HookManager.cs
@@ -206,6 +206,12 @@ namespace DvMod.ZCouplers.Visuals
             if (coupler.train?.gameObject == null)
                 return;
 
+            if (coupler.train?.carLivery?.id == "LocoDE6Slug")
+            {
+                ToggleAirHoseVisibility(coupler, true);
+                return;
+            }
+
             // For profiles that always hide air hoses (e.g., Schaku), enforce it
             if (CouplerProfiles.Current?.Options.AlwaysHideAirHoses == true)
             {


### PR DESCRIPTION
## Summary
- Keep hose hardware visible for the vanilla DE6 Slug (`LocoDE6Slug`) when ZCouplers toggles air hose visibility.
- This preserves the physical MU/air connection points needed to use the slug with DE locomotives.

Fixes #14.

## Root cause
ZCouplers hides/shows the direct `hoses` child under a car interior while applying coupler visuals. On the DE6 Slug, that hardware includes the connection points players need for slug setup. The slug is a special case because it requires the MU cable to function.

## Validation
- Confirmed in-game that disabling ZCouplers restores the DE6 Slug hose/MU hardware.
- Built and installed this one-line special-case patch locally; the slug hose/MU hardware returned while ZCouplers stayed enabled.
- Ran `dotnet build ZCouplers/ZCouplers.csproj -c Release --no-self-contained`. Compilation produced `ZCouplers.dll`, then the upstream post-build asset-copy step failed because the source checkout does not include `ZCouplers.Unity/Assets/AssetBundles/aar`.